### PR TITLE
Feature fix changing video name error

### DIFF
--- a/lib/vimeo_me2/video.rb
+++ b/lib/vimeo_me2/video.rb
@@ -45,7 +45,7 @@ module VimeoMe2
     def update
       body = @video
       # temporary fix, because API does not accept privacy in request
-      body.delete('privacy')
+      body.delete('embed')
       body.delete('type')
       patch(nil, body:body, code:[200,204])
     end


### PR DESCRIPTION
Modify the key deleted when the video will be updated because  'W4A0F6' error occurs